### PR TITLE
Basic authentication and profile fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,27 @@ This application is currently in development. It's being completely rewritten an
 
 ### To do:
 - General
-    - [x] Move to a global app context (useContext)
+    - [ ] Add an info/about page or modal
+    - [ ] Adjust handicap (default: a value within 25pts of the target is correct)
+    - [ ] Select a color family to streamline guessing
+    - [ ] Add a social/sharing feature for results
+    - [x] Move local variables to useContext
 - Navigation
     - [x] Integrate log in session info with app navigation
 - Styling
+    - [ ] Sound effectss
     - [ ] Finish styling
+    - [ ] More feedback in general
 - Login and registration
-    - [ ] Redirect after logging in
     - [ ] Add retry cooldown
+    - [ ] Add more feedback/info to login/registration
     - [x] Rework login with better salt/hash protocols
 - Profile page
-    - [ ] Show win/lose stats
-    - [ ] Show winning color swatches
+    - [ ] Display by newest to oldest
+    - [ ] Paginate results
+    - [ ] View others' profiles
+    - [x] Show win/lose stats
+    - [x] Show winning color swatches
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,41 @@
 import './App.css';
 import { Menu } from './components/Menu';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import LoginContext from './context/LoginContext';
-import { useLocation, Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import { Profile } from './pages/Profile';
 import { Home } from './pages/Home';
 
 export default function App() {
 
-  const { userId } = useContext(LoginContext);
+  const { dispatch, userId } = useContext(LoginContext);
+
+  useEffect(() => {
+
+    function CheckAuth() {
+      var checked = false;
+      if (!checked) {
+        // Check if there's a cookie from a previous login
+        const cookieId = document.cookie.split("=")[1];
+        if (cookieId !== undefined) {
+          // Use the cookie as the context userId
+          console.log("There is a login cookie.");
+          dispatch({ type: 'SET_USERID', payload: cookieId });
+        } else {
+          // No cookie found
+          console.log("There is NOT a login cookie.");
+          dispatch({ type: 'SET_USERID', payload: null });
+        }
+        checked = true;
+      }
+    }
+
+    CheckAuth()
+  }, [dispatch, userId])
+
+
 
   function RequireAuth({ children }: { children: JSX.Element }) {
-    let location = useLocation();
 
     if (!userId) {
       // Redirect to home
@@ -23,7 +47,7 @@ export default function App() {
 
   return (
     <Routes>
-      <Route element={<Menu loggedIn={userId ? true : false}/>}>
+      <Route element={<Menu loggedIn={userId ? true : false} />}>
         <Route path="guessRGB/" element={<Home />} />
         <Route path="guessRGB/profile"
           element={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,37 @@
 import './App.css';
-import { Home } from "./pages/Home";
-import { Profile } from './pages/Profile';
 import { Menu } from './components/Menu';
+import { useContext } from 'react';
+import LoginContext from './context/LoginContext';
+import { useLocation, Navigate, Route, Routes } from 'react-router-dom';
+import { Profile } from './pages/Profile';
+import { Home } from './pages/Home';
 
-function App() {
+export default function App() {
+
+  const { userId } = useContext(LoginContext);
+
+  function RequireAuth({ children }: { children: JSX.Element }) {
+    let location = useLocation();
+
+    if (!userId) {
+      // Redirect to home
+      return <Navigate to="/guessRGB/" />;
+    }
+
+    return children;
+  }
 
   return (
-    <>
-      <Menu />
-      <Profile />
-      <Home />
-    </>
+    <Routes>
+      <Route element={<Menu loggedIn={userId ? true : false}/>}>
+        <Route path="guessRGB/" element={<Home />} />
+        <Route path="guessRGB/profile"
+          element={
+            <RequireAuth>
+              <Profile />
+            </RequireAuth>
+          } />
+      </Route>
+    </Routes>
   );
 }
-
-export default App;

--- a/src/backend/database/session.js
+++ b/src/backend/database/session.js
@@ -4,8 +4,11 @@ module.exports = {
     sessionOptions: {
         secret: process.env.SESSION_SECRET,
         cookie: { maxAge: 20000, httpOnly: true, signed: true },
-        saveUninitialized: true,
+        saveUninitialized: false,
         resave: false,
-        store: MongoStore.create({ mongoUrl: process.env.ATLAS_URI, ttl: 20000 })
+        store: MongoStore.create({
+            mongoUrl: process.env.ATLAS_URI,
+            ttl: 20000
+        })
     }
 }

--- a/src/backend/models/session.model.js
+++ b/src/backend/models/session.model.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose')
+
+// Session data
+const Session = new mongoose.Schema(
+    {
+        expires: { type: Date, required: true },
+        session: { type: String, required: true },
+    },
+    {collection: 'sessions'}
+)
+
+const model = mongoose.model('SessionData', Session)
+
+module.exports = model

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,7 +1,10 @@
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { Button, Form } from "react-bootstrap";
+import LoginContext from "../context/LoginContext";
 
 export const Login = () => {
+
+    const { dispatch } = useContext(LoginContext);
 
     const [validated, setValidated] = useState(false);
     const [inputs, setInputs] = useState({
@@ -23,13 +26,9 @@ export const Login = () => {
         setValidated(true);
         const form = e.currentTarget.parentElement;
         if (form.checkValidity() === false) {
-            // console.log(form.checkValidity());
             return e.stopPropagation();
         }
-
-        // console.log(form.checkValidity());
-
-        await fetch(`http://localhost:5000/api/login`,
+        const request = await fetch(`http://localhost:5000/api/login`,
             {
                 method: 'POST',
                 headers: {
@@ -38,59 +37,62 @@ export const Login = () => {
                 credentials: 'include',
                 body: JSON.stringify(inputs)
             })
-            .then((response) => {
-                console.log(response);
-                if (response.status == 200) {
-                    alert("Log in successful!");
-                } else {
-                    alert("Log in unsuccessful.");
-                }
-            })
+
+        const response = await request.json()
+        console.log(response);
+        if (response.status === 'success') {
+            alert("Log in successful!");
+            document.cookie = `userId=${response.session.userId}; expires=${new Date(response.session.cookie.expires).toUTCString()}; path=${response.session.cookie.path}`;
+            dispatch({ type: 'SET_USERID', payload: response.session.userId });
+        } else {
+            alert("Log in unsuccessful.");
+        }
     }
 
-    return (
-        <Form noValidate validated={validated}>
-            <Form.Group className="mb-3">
-                <Form.Label>Email</Form.Label>
-                <Form.Control
-                    required
-                    type="email"
-                    id="email"
-                    minLength={6}
-                    maxLength={50}
-                    value={inputs.email}
-                    onChange={handleChange} />
-                <Form.Text>Please enter your email address.</Form.Text>
-            </Form.Group>
-            <Form.Group className="mb-3">
-                <Form.Label>Password</Form.Label>
-                <Form.Control
-                    required
-                    type="password"
-                    id="password"
-                    minLength={8}
-                    maxLength={12}
-                    value={inputs.password}
-                    onChange={handleChange} />
-                <Form.Text>Please enter your password.</Form.Text>
-            </Form.Group>
 
-            <Form.Group className="mb-3 text-start">
-                <Form.Check
-                    type="checkbox"
-                    id="rememberUser"
-                    label="Remember me"
-                    value={inputs.rememberUser}
-                    onChange={(e) => {
-                        const { id, value } = e.target
-                        setInputs((inputs) => ({
-                            ...inputs,
-                            [id]: value === "false" ? "true" : "false",
-                        }))
-                    }}
-                />
-            </Form.Group>
-            <Button type="submit" onClick={handleSubmit}>Log in</Button>
-        </Form>
-    )
+return (
+    <Form noValidate validated={validated}>
+        <Form.Group className="mb-3">
+            <Form.Label>Email</Form.Label>
+            <Form.Control
+                required
+                type="email"
+                id="email"
+                minLength={6}
+                maxLength={50}
+                value={inputs.email}
+                onChange={handleChange} />
+            <Form.Text>Please enter your email address.</Form.Text>
+        </Form.Group>
+        <Form.Group className="mb-3">
+            <Form.Label>Password</Form.Label>
+            <Form.Control
+                required
+                type="password"
+                id="password"
+                minLength={8}
+                maxLength={12}
+                value={inputs.password}
+                onChange={handleChange} />
+            <Form.Text>Please enter your password.</Form.Text>
+        </Form.Group>
+
+        <Form.Group className="mb-3 text-start">
+            <Form.Check
+                type="checkbox"
+                id="rememberUser"
+                label="Remember me"
+                value={inputs.rememberUser}
+                onChange={(e) => {
+                    const { id, value } = e.target
+                    setInputs((inputs) => ({
+                        ...inputs,
+                        [id]: value === "false" ? "true" : "false",
+                    }))
+                }}
+            />
+        </Form.Group>
+        <Button type="submit" onClick={handleSubmit}>Log in</Button>
+    </Form>
+)
 }

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -41,11 +41,10 @@ export const Login = () => {
         const response = await request.json()
         console.log(response);
         if (response.status === 'success') {
-            alert("Log in successful!");
             document.cookie = `userId=${response.session.userId}; expires=${new Date(response.session.cookie.expires).toUTCString()}; path=${response.session.cookie.path}`;
             dispatch({ type: 'SET_USERID', payload: response.session.userId });
         } else {
-            alert("Log in unsuccessful.");
+            alert("Sorry, we weren't able to log you in with that information!");
         }
     }
 

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -71,8 +71,9 @@ export const Menu = (loggedIn: {loggedIn: boolean}) => {
             .then((response) => {
                 console.log(response);
                 if (response.status === 200) {
-                    alert("Log out successful!");
-                    return dispatch({ type: 'SET_USERID', payload: null });
+                    dispatch({ type: 'SET_USERID', payload: null });
+                    dispatch({ type: 'SET_FETCHED_HISTORY', payload: null });
+                    return dispatch({ type: 'SET_FETCH_COMPLETE', payload: false });
                 } else {
                     alert("Log out unsuccessful.");
                 }

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,63 +1,18 @@
 import Offcanvas from 'react-bootstrap/Offcanvas'
-import { useContext, useEffect, useState } from "react"
+import { useContext, useState } from "react"
 import { Login } from './Login'
 import { Register } from './Register'
 import { Button, Container, Nav } from 'react-bootstrap'
-import { Link, Navigate, Outlet } from 'react-router-dom'
+import { Link, Outlet } from 'react-router-dom'
 import LoginContext from '../context/LoginContext'
 
-export const Menu = (loggedIn: {loggedIn: boolean}) => {
+export const Menu = (loggedIn: { loggedIn: boolean }) => {
 
-    const { dispatch, userId } = useContext(LoginContext);
+    const { dispatch } = useContext(LoginContext);
 
     const [showMenu, setShowMenu] = useState(false)
     const [showLogin, setShowLogin] = useState(true)
     const [showRegister, setShowRegister] = useState(false)
-
-    const checkAuth = async () => {
-        var authId = null;
-
-        if (userId == null) {
-            // Check if there's a cookie from a previous login
-            const cookieId = document.cookie.split("=")[1];
-            if (cookieId !== undefined) {
-                // Use the cookie as the context userId
-                authId = cookieId;
-                console.log("There is a login cookie");
-                dispatch({ type: 'SET_USERID', payload: cookieId });
-            } else {
-                // No cookie found
-                console.log("There is NOT a login cookie.");
-            }
-        } else {
-            // UserId has already been set. User is already logged in.
-            authId = userId;
-            dispatch({ type: 'SET_USERID', payload: authId });
-        }
-
-        // Get session from cookie
-        /*
-        if (userId == null && authId !== null) {
-            const request = await fetch(`http://localhost:5000/api/auth`,
-                {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({ userId: authId })
-                })
-            const response = await request.json()
-            if (response.userId !== null) {
-                console.log("User is logged in from session.");
-                dispatch({ type: 'SET_USERID', payload: response.userId });
-            } else {
-                console.log("User is NOT logged in from session.");
-                setLoggedIn(false)
-            }
-        }
-        */
-    }
-
 
     const logOut = async () => {
         await fetch(`http://localhost:5000/api/logout`,
@@ -75,14 +30,10 @@ export const Menu = (loggedIn: {loggedIn: boolean}) => {
                     dispatch({ type: 'SET_FETCHED_HISTORY', payload: null });
                     return dispatch({ type: 'SET_FETCH_COMPLETE', payload: false });
                 } else {
-                    alert("Log out unsuccessful.");
+                    console.error("Log out unsuccessful.");
                 }
             })
     }
-
-    useEffect(() => {
-        checkAuth();
-    }, [dispatch])
 
     return (
         <>
@@ -109,7 +60,11 @@ export const Menu = (loggedIn: {loggedIn: boolean}) => {
                                     <Link to={"/guessRGB/profile"} className="nav-link">Profile</Link>
                                 </Nav.Item>
                                 <Nav.Item>
-                                    <Nav.Link onClick={() => logOut()}>Log out</Nav.Link>
+                                    <Nav.Link onClick={() => {
+                                        setShowRegister(false)
+                                        setShowLogin(true)
+                                        logOut()
+                                    }}>Log out</Nav.Link>
                                 </Nav.Item>
                             </div>
                             :

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -3,17 +3,16 @@ import { useContext, useEffect, useState } from "react"
 import { Login } from './Login'
 import { Register } from './Register'
 import { Button, Container, Nav } from 'react-bootstrap'
-import { Link, Outlet } from 'react-router-dom'
+import { Link, Navigate, Outlet } from 'react-router-dom'
 import LoginContext from '../context/LoginContext'
 
-export const Menu = () => {
+export const Menu = (loggedIn: {loggedIn: boolean}) => {
 
     const { dispatch, userId } = useContext(LoginContext);
 
     const [showMenu, setShowMenu] = useState(false)
     const [showLogin, setShowLogin] = useState(true)
     const [showRegister, setShowRegister] = useState(false)
-    const [loggedIn, setLoggedIn] = useState(false)
 
     const checkAuth = async () => {
         var authId = null;
@@ -26,17 +25,14 @@ export const Menu = () => {
                 authId = cookieId;
                 console.log("There is a login cookie");
                 dispatch({ type: 'SET_USERID', payload: cookieId });
-                setLoggedIn(true);
             } else {
                 // No cookie found
-                setLoggedIn(false);
                 console.log("There is NOT a login cookie.");
             }
         } else {
             // UserId has already been set. User is already logged in.
             authId = userId;
             dispatch({ type: 'SET_USERID', payload: authId });
-            setLoggedIn(true)
         }
 
         // Get session from cookie
@@ -76,8 +72,7 @@ export const Menu = () => {
                 console.log(response);
                 if (response.status === 200) {
                     alert("Log out successful!");
-                    dispatch({ type: 'SET_USERID', payload: null });
-                    setLoggedIn(false)
+                    return dispatch({ type: 'SET_USERID', payload: null });
                 } else {
                     alert("Log out unsuccessful.");
                 }
@@ -86,7 +81,7 @@ export const Menu = () => {
 
     useEffect(() => {
         checkAuth();
-    })
+    }, [dispatch])
 
     return (
         <>
@@ -103,11 +98,11 @@ export const Menu = () => {
                     <Offcanvas.Title>Menu</Offcanvas.Title>
                 </Offcanvas.Header>
                 <Offcanvas.Body className='flex-row text-center'>
-                    <Nav variant="pills" className='d-inline' justify defaultActiveKey={loggedIn ? undefined : "login"}>
+                    <Nav variant="pills" className='d-inline' justify defaultActiveKey={loggedIn.loggedIn ? undefined : "login"}>
                         <Nav.Item>
-                            <Link to={"/guessRGB/home"} className="nav-link">Home</Link>
+                            <Link to={"/guessRGB"} className="nav-link">Home</Link>
                         </Nav.Item>
-                        {loggedIn ?
+                        {loggedIn.loggedIn ?
                             <div>
                                 <Nav.Item>
                                     <Link to={"/guessRGB/profile"} className="nav-link">Profile</Link>
@@ -119,13 +114,13 @@ export const Menu = () => {
                             :
                             <div>
                                 <Nav.Item>
-                                    <Nav.Link eventKey="login" onClick={(e) => {
+                                    <Nav.Link eventKey="login" onClick={() => {
                                         setShowRegister(false)
                                         setShowLogin(true)
                                     }}>Log in</Nav.Link>
                                 </Nav.Item>
                                 <Nav.Item>
-                                    <Nav.Link eventKey="register" onClick={(e) => {
+                                    <Nav.Link eventKey="register" onClick={() => {
                                         setShowLogin(false)
                                         setShowRegister(true)
                                     }}>Register</Nav.Link>

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -8,12 +8,59 @@ import LoginContext from '../context/LoginContext'
 
 export const Menu = () => {
 
-    const { dispatch } = useContext(LoginContext);
+    const { dispatch, userId } = useContext(LoginContext);
 
     const [showMenu, setShowMenu] = useState(false)
     const [showLogin, setShowLogin] = useState(true)
     const [showRegister, setShowRegister] = useState(false)
-    const [loggedIn, setLoggedIn] = useState(true)
+    const [loggedIn, setLoggedIn] = useState(false)
+
+    const checkAuth = async () => {
+        var authId = null;
+
+        if (userId == null) {
+            // Check if there's a cookie from a previous login
+            const cookieId = document.cookie.split("=")[1];
+            if (cookieId !== undefined) {
+                // Use the cookie as the context userId
+                authId = cookieId;
+                console.log("There is a login cookie");
+                dispatch({ type: 'SET_USERID', payload: cookieId });
+                setLoggedIn(true);
+            } else {
+                // No cookie found
+                setLoggedIn(false);
+                console.log("There is NOT a login cookie.");
+            }
+        } else {
+            // UserId has already been set. User is already logged in.
+            authId = userId;
+            dispatch({ type: 'SET_USERID', payload: authId });
+            setLoggedIn(true)
+        }
+
+        // Get session from cookie
+        /*
+        if (userId == null && authId !== null) {
+            const request = await fetch(`http://localhost:5000/api/auth`,
+                {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ userId: authId })
+                })
+            const response = await request.json()
+            if (response.userId !== null) {
+                console.log("User is logged in from session.");
+                dispatch({ type: 'SET_USERID', payload: response.userId });
+            } else {
+                console.log("User is NOT logged in from session.");
+                setLoggedIn(false)
+            }
+        }
+        */
+    }
 
 
     const logOut = async () => {
@@ -27,13 +74,19 @@ export const Menu = () => {
             })
             .then((response) => {
                 console.log(response);
-                if (response.status == 200) {
+                if (response.status === 200) {
                     alert("Log out successful!");
+                    dispatch({ type: 'SET_USERID', payload: null });
+                    setLoggedIn(false)
                 } else {
                     alert("Log out unsuccessful.");
                 }
             })
     }
+
+    useEffect(() => {
+        checkAuth();
+    })
 
     return (
         <>

--- a/src/context/GameContext.js
+++ b/src/context/GameContext.js
@@ -7,6 +7,7 @@ export const GameProvider = ({ children }) => {
     const initialState = {
         gamePlaying: true,
         gameWon: false,
+        recordedResult: false,
         guesses: [],
         correctAnswer: {
             r: Math.round(Math.random() * 255),

--- a/src/context/GameReducer.js
+++ b/src/context/GameReducer.js
@@ -21,6 +21,11 @@ const gameReducer = (state, action) => {
                 ...state,
                 correctAnswer: action.payload,
             };
+        case 'SET_RECORDED_RESULT':
+            return {
+                ...state,
+                recordedResult: action.payload,
+            };
         default:
             return state
     };

--- a/src/context/LoginActions.js
+++ b/src/context/LoginActions.js
@@ -1,0 +1,12 @@
+export const signin = (newUser, callback) => {
+    return fakeAuthProvider.signin(() => {
+        setUser(newUser);
+        callback();
+    });
+};
+export const signout = (callback) => {
+    return fakeAuthProvider.signout(() => {
+        setUser(null);
+        callback();
+    });
+};

--- a/src/context/LoginContext.js
+++ b/src/context/LoginContext.js
@@ -7,6 +7,8 @@ export const LoginProvider = ({ children }) => {
     const initialState = {
         isLoading: false,
         userId: null,
+        fetchComplete: null,
+        fetchedHistory: null,
     };
 
     const [state, dispatch] = useReducer(loginReducer, initialState);

--- a/src/context/LoginReducer.js
+++ b/src/context/LoginReducer.js
@@ -11,6 +11,16 @@ const loginReducer = (state, action) => {
                 ...state,
                 userId: action.payload,
             };
+        case 'SET_FETCH_COMPLETE':
+            return {
+                ...state,
+                fetchComplete: action.payload,
+            };
+        case 'SET_FETCHED_HISTORY':
+            return {
+                ...state,
+                fetchedHistory: action.payload,
+            };
         default:
             return state
     };

--- a/src/index.css
+++ b/src/index.css
@@ -19,14 +19,14 @@ div[id^="guessContainer"], #answerText, .guessContainer {
 }
 
 .historyHeader {
-  color: #000000;
+  color: #ffffff;
   font-size: 1.5em;
   font-variant: small-caps;
   font-weight: bolder;
-  text-shadow: 1px 0px 0px rgba(255, 255, 255, 0.5),
-    -1px -0px 0px  rgba(255, 255, 255, 0.5),
-    0px 1px 0px  rgba(255, 255, 255, 0.5),
-    0px -1px 0px  rgba(255, 255, 255, 0.5);
+  text-shadow: 1px 0px 0px rgba(0, 0, 0),
+    -1px -0px 0px  rgba(0, 0, 0),
+    0px 1px 0px  rgba(0, 0, 0),
+    0px -1px 0px  rgba(0, 0, 0);
 }
 
 .slideDown {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,38 +1,21 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client'
 import './index.css';
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import { Profile } from './pages/Profile';
-import { Menu } from './components/Menu';
-import { Home } from './pages/Home';
 import { LoginProvider } from './context/LoginContext';
 import { GameProvider } from './context/GameContext';
+import App from './App';
+import { BrowserRouter } from 'react-router-dom';
 
 const container = document.getElementById('root')
 const root = createRoot(container!)
-
-const router = createBrowserRouter([
-  {
-    path: "/guessRGB",
-    element: <Menu />,
-    children: [
-      {
-        path: "/guessRGB/home",
-        element: <Home />,
-      },
-      {
-        path: "/guessRGB/profile",
-        element: <Profile />,
-      },
-    ],
-  },
-]);
 
 root.render(
   <React.StrictMode>
     <LoginProvider>
       <GameProvider>
-        <RouterProvider router={router} />
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
       </GameProvider>
     </LoginProvider>
   </React.StrictMode>,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from "react"
+import { useContext, useEffect, useState } from "react"
 import { Button, Container } from "react-bootstrap"
 import GameContext from "../context/GameContext"
 import HexToRgb from "../utilities/HexToRGB"
@@ -12,6 +12,7 @@ export const Home = () => {
 
     const { dispatch, gamePlaying, gameWon, correctAnswer, guesses } = useContext(GameContext);
     const { userId } = useContext(LoginContext);
+    const [recordedResult, setRecordedResult] = useState(false);
 
 
 
@@ -39,17 +40,20 @@ export const Home = () => {
         const data = await response.json()
         if (data.status === "success") {
             console.log(data)
-            alert("Recorded result!");
+            return alert("Recorded result!");
         } else {
             console.log(data)
-            alert("Unable to record result.");
+            return alert("Unable to record result.");
         }
     }
 
     useEffect(() => {
-        if (!gamePlaying) {
-            recordResult();
-        }
+        if (!gamePlaying &&
+            userId !== null &&
+            recordedResult !== true) {
+                recordResult();
+                setRecordedResult(true);
+            }
     }, [gamePlaying, guesses, recordResult])
 
 
@@ -89,6 +93,7 @@ export const Home = () => {
         });
         dispatch({ type: 'SET_GAMEWON', payload: false });
         dispatch({ type: 'SET_GAMEPLAYING', payload: true });
+        setRecordedResult(false);
     }
 
     return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from "react"
+import { useContext, useEffect } from "react"
 import { Button, Container } from "react-bootstrap"
 import GameContext from "../context/GameContext"
 import HexToRgb from "../utilities/HexToRGB"
@@ -10,11 +10,8 @@ import LoginContext from "../context/LoginContext"
 
 export const Home = () => {
 
-    const { dispatch, gamePlaying, gameWon, correctAnswer, guesses } = useContext(GameContext);
+    const { dispatch, gamePlaying, gameWon, correctAnswer, guesses, recordedResult } = useContext(GameContext);
     const { userId } = useContext(LoginContext);
-    const [recordedResult, setRecordedResult] = useState(false);
-
-
 
     const recordResult = async () => {
 
@@ -51,11 +48,10 @@ export const Home = () => {
         if (!gamePlaying &&
             userId !== null &&
             recordedResult !== true) {
-                recordResult();
-                setRecordedResult(true);
-            }
-    }, [gamePlaying, guesses, recordResult])
-
+            recordResult();
+            dispatch({ type: 'SET_RECORDED_RESULT', payload: true });
+        }
+    })
 
     const recordGuess = (hexValue: string) => {
         console.log(`The correct answer is: ${correctAnswer.r}, ${correctAnswer.g}, ${correctAnswer.b} `)
@@ -93,7 +89,7 @@ export const Home = () => {
         });
         dispatch({ type: 'SET_GAMEWON', payload: false });
         dispatch({ type: 'SET_GAMEPLAYING', payload: true });
-        setRecordedResult(false);
+        dispatch({ type: 'SET_RECORDED_RESULT', payload: false });
     }
 
     return (

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,19 +1,19 @@
-import { useContext, useState } from "react"
+import { useContext, useEffect, useState } from "react"
 import { Container } from "react-bootstrap"
 import { GuessDisplayH } from "../components/GuessDisplayH";
 import LoginContext from "../context/LoginContext";
 
 export const Profile = () => {
     const [gameHistory, setGameHistory] = useState(null);
+    const [fetched, setFetched] = useState(false);
 
-    const { dispatch, userId } = useContext(LoginContext);
+    const { userId } = useContext(LoginContext);
 
-    const fetchHistory = async () => {
-        var result;
 
-        if (gameHistory == null) {
 
-        if (userId !== null) {
+    useEffect(() => {
+
+        const fetchHistory = async () => {
             const response = await fetch(`http://localhost:5000/api/games/${userId}`,
                 {
                     method: 'GET',
@@ -24,28 +24,30 @@ export const Profile = () => {
             )
             const data = await response.json()
             if (data.status === "success") {
-                result = data;
-                console.log(data.history)
                 setGameHistory(data.history)
 
             } else {
-                result = data;
+                console.log("No games found.")
             }
+
+            return console.log(data)
         }
-        // console.log(gameHistory)
-        return console.log(result)
-    }
-}
+
+        if (gameHistory == null && userId !== null && fetched !== true) {
+            fetchHistory();
+            console.log("Done fetching history.")
+            setFetched(true);
+        }
+    }, [gameHistory, userId, fetched])
 
 
-    return (fetchHistory(),
-        <>
-            <Container>
-                <h3>{userId ? `Hello!` : "You're not logged in!"}</h3>
 
-                <h4>This is your game history:</h4>
-                {gameHistory !== null ? <GuessDisplayH games={gameHistory}/> : null}
-            </Container>
-        </>
+    return (
+        <Container>
+            <h3>{userId ? `Hello!` : "You're not logged in!"}</h3>
+
+            <h4>This is your game history:</h4>
+            {gameHistory !== null ? <GuessDisplayH games={gameHistory} /> : null}
+        </Container>
     )
 }

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,53 +1,47 @@
-import { useContext, useEffect, useState } from "react"
+import { useContext, useEffect } from "react"
 import { Container } from "react-bootstrap"
 import { GuessDisplayH } from "../components/GuessDisplayH";
 import LoginContext from "../context/LoginContext";
 
 export const Profile = () => {
-    const [gameHistory, setGameHistory] = useState(null);
-    const [fetched, setFetched] = useState(false);
-
-    const { userId } = useContext(LoginContext);
-
-
+    const { dispatch, userId, fetchedHistory, fetchComplete } = useContext(LoginContext);
 
     useEffect(() => {
+        if (!fetchComplete) {
+            fetchHistory()
+            dispatch({ type: 'SET_FETCH_COMPLETE', payload: true });
+        }
+    })
 
-        const fetchHistory = async () => {
-            const response = await fetch(`http://localhost:5000/api/games/${userId}`,
-                {
-                    method: 'GET',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    }
+    const fetchHistory = async () => {
+        const response = await fetch(`http://localhost:5000/api/games/${userId}`,
+            {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json'
                 }
-            )
-            const data = await response.json()
-            if (data.status === "success") {
-                setGameHistory(data.history)
-
+            }
+        )
+        const data = await response.json()
+        if (data.status === "success") {
+            if (data.history) {
+                dispatch({ type: 'SET_FETCHED_HISTORY', payload: data.history });
             } else {
                 console.log("No games found.")
             }
 
-            return console.log(data)
+        } else {
+            console.log("No games found.")
         }
-
-        if (gameHistory == null && userId !== null && fetched !== true) {
-            fetchHistory();
-            console.log("Done fetching history.")
-            setFetched(true);
-        }
-    }, [gameHistory, userId, fetched])
-
-
+        return console.log(data)
+    }
 
     return (
         <Container>
             <h3>{userId ? `Hello!` : "You're not logged in!"}</h3>
 
             <h4>This is your game history:</h4>
-            {gameHistory !== null ? <GuessDisplayH games={gameHistory} /> : null}
+            {fetchComplete && fetchedHistory ? <GuessDisplayH games={fetchedHistory} /> : <div>No games found.</div>}
         </Container>
     )
 }

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from "react"
-import { Container } from "react-bootstrap"
+import { Button, Container } from "react-bootstrap"
 import { GuessDisplayH } from "../components/GuessDisplayH";
 import LoginContext from "../context/LoginContext";
 
@@ -40,7 +40,7 @@ export const Profile = () => {
         <Container>
             <h3>{userId ? `Hello!` : "You're not logged in!"}</h3>
 
-            <h4>This is your game history:</h4>
+            <h4>This is your game history:</h4> <Button onClick={() => fetchHistory()}>Reload</Button>
             {fetchComplete && fetchedHistory ? <GuessDisplayH games={fetchedHistory} /> : <div>No games found.</div>}
         </Container>
     )

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -41,7 +41,7 @@ export const Profile = () => {
             <h3>{userId ? `Hello!` : "You're not logged in!"}</h3>
 
             <h4>This is your game history:</h4> <Button onClick={() => fetchHistory()}>Reload</Button>
-            {fetchComplete && fetchedHistory ? <GuessDisplayH games={fetchedHistory} /> : <div>No games found.</div>}
+            {fetchComplete ? (fetchedHistory ? <GuessDisplayH games={fetchedHistory} /> : <div>No games found.</div>) : <div>Loading...</div>}
         </Container>
     )
 }


### PR DESCRIPTION
- Moved routing from Index to App
- Added redirect from Profile if user is not logged in
- App's useEffect (checkAuth) checks the cookie that's created on login. This logs the user back in when the site is refreshed or revisited
- Set saveUninitialized to false, preventing an issue where 2 sessions were being created when a new GET was sent from the Profile page after the user was already logged in. This cuts back significantly on the number of sessions being saved to MongoDB
- Added a "reload" button to the Profile page so that a user can reload after submitting a new game.
- Fixed game submission loop
- Changed .historyHeader styling to the same white with black border text style for now
- Misc logging and response changes